### PR TITLE
Fix curative vat claiming metadata 0 has a TileEntity when it does not

### DIFF
--- a/src/main/java/fr/wind_blade/isorropia/common/blocks/BlockCurativeVat.java
+++ b/src/main/java/fr/wind_blade/isorropia/common/blocks/BlockCurativeVat.java
@@ -77,6 +77,11 @@ public class BlockCurativeVat extends Block implements ITileEntityProvider, IBlo
         return Items.AIR;
     }
 
+    @Override
+    public boolean hasTileEntity(IBlockState state) {
+        return state.getValue(VARIANT) != Type.PLACEHOLDER;
+    }
+
     public TileEntity createNewTileEntity(World worldIn, int meta) {
         switch (meta) {
             case 1: {


### PR DESCRIPTION
Fixes [this ThaumcraftFix issue](https://github.com/TheCodex6824/ThaumcraftFix/issues/79) (and potentially other issues with Sponge).